### PR TITLE
Add global MUI theme and reusable CTAButton component

### DIFF
--- a/src/components/ui/CTAButton.tsx
+++ b/src/components/ui/CTAButton.tsx
@@ -1,0 +1,65 @@
+// src/components/ui/CTAButton.tsx
+
+import { Button } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import React from 'react';
+
+type CTAButtonVariant = 'black' | 'green';
+
+interface CTAButtonProps {
+  children: React.ReactNode;
+  onClick?: () => void;
+  href?: string;
+  endIcon?: React.ReactNode;
+  variant?: CTAButtonVariant;
+}
+
+export default function CTAButton({
+  children,
+  onClick,
+  href,
+  endIcon,
+  variant = 'black',
+}: CTAButtonProps) {
+  const theme = useTheme();
+  
+  const stylesByVariant = {
+    black: {
+      bgcolor: '#060606',
+      color: '#ffffff',
+      '&:hover': {
+        bgcolor: '#060606',
+        opacity: 0.9,
+      },
+    },
+    green: {
+      bgcolor: '#a8f574',
+      color: '#060606',
+      '&:hover': {
+        bgcolor: '#a8f574',
+        opacity: 0.9,
+      },
+    },
+  };
+
+  return (
+    <Button
+      variant="contained"
+      onClick={onClick}
+      href={href}
+      endIcon={endIcon}
+      sx={{
+        borderRadius: '16px',
+        padding: '13px 61px',
+        fontFamily: theme.typography.fontFamily,
+        fontSize: theme.typography.button.fontSize,
+        textTransform: 'none',
+        fontWeight: theme.typography.button.fontWeight,
+        height: '48px',
+        ...stylesByVariant[variant],
+      }}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/src/components/ui/CTAButton.tsx
+++ b/src/components/ui/CTAButton.tsx
@@ -1,4 +1,5 @@
 // src/components/ui/CTAButton.tsx
+'use client';
 
 import { Button } from '@mui/material';
 import { useTheme } from '@mui/material/styles';

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,81 @@
+// theme/index.ts
+import { createTheme, responsiveFontSizes } from '@mui/material/styles';
+
+//color
+//font-size
+//padding
+//responsive
+
+
+let theme = createTheme({
+  spacing: 8, // 默认 spacing 单位（8px）
+
+  palette: {
+    background: {
+      default: '#f9f9f9',
+      paper: '#ffffff',
+    },
+    text: {
+      primary: '#060606',
+      secondary: '#6d6d6d',
+    },
+  },
+
+
+  typography: {
+    fontSize: 16,
+    fontFamily: ['Roboto', 'sans-serif'].join(','),
+    h1: {
+      fontSize: '4.5rem',
+      fontWeight: 700,
+    },
+    h2: {
+      fontSize: '3.5rem',
+      fontWeight: 700,
+    },
+    h3: {
+      fontSize: '1.5rem',
+      fontWeight: 700,
+    },
+    body1: {
+      fontSize: '1.25rem',
+    },
+    body2: {
+      fontSize: '1rem',
+    },
+    button: {
+      fontSize: '0.75rem',
+      fontWeight: 700,
+    },
+  },
+
+  breakpoints: {
+    values: {
+      xs: 0,    // mobile devices (<768px)
+      sm: 768,   // desktop (≥768px)
+      md: 768,   // 保持与sm相同，实际不会用到
+      lg: 768,   // 保持与sm相同，实际不会用到
+      xl: 768,   // 保持与sm相同，实际不会用到
+    },
+  },
+
+  components: {
+    MuiContainer: {
+      styleOverrides: {
+        root: {
+          paddingLeft: '16px',
+          paddingRight: '16px',
+          '@media (min-width:768px)': { 
+            paddingLeft: '64px',
+            paddingRight: '64px',
+          },
+        },
+      },
+    },
+  },
+});
+
+
+theme = responsiveFontSizes(theme);
+
+export default theme;

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,10 +1,6 @@
 // theme/index.ts
 import { createTheme, responsiveFontSizes } from '@mui/material/styles';
 
-//color
-//font-size
-//padding
-//responsive
 
 
 let theme = createTheme({


### PR DESCRIPTION
**Summary**
This pull request introduces two key additions to the codebase:
1. Global MUI Theme Configuration (theme/index.ts)
2. Reusable CTA Button Component (components/ui/CTAButton.tsx)



**Global Theme (theme/index.ts)**
  - Defined base spacing (spacing: 8) for consistent layout.
  - Customized palette for background and text colors.
  - Configured typography for h1, h2, h3, body1, body2, and button, using Roboto as the primary font.
  - Simplified breakpoints to only handle two screen sizes: mobile (<768px) and desktop (≥768px).
  - Applied responsive font scaling using responsiveFontSizes(theme).



**CTA Button (CTAButton.tsx)**
Created a reusable CTAButton component using MUI's Button.
  - black (dark background, white text)
  - green (light green background, dark text)