### PR TITLE
bugfix/DIS-27-Hero-Section

### DIFF
--- a/src/app/landing/components/HeroSection.tsx
+++ b/src/app/landing/components/HeroSection.tsx
@@ -39,12 +39,9 @@ const StyledHeader = styled('h1')`
   font-family: ${({ theme }) => theme.typography.h1.fontFamily};
   font-weight: ${({ theme }) => theme.typography.h1.fontWeight};
   margin: 0;
+  overflow-wrap: anywhere;
 
-  @media (min-width: ${({ theme }) => theme.breakpoints.values.sm}px) {
-    font-size: ${({ theme }) => theme.typography.h3.fontSize};
-  }
-
-  @media (min-width: ${({ theme }) => theme.breakpoints.values.md}px) {
+  @media (max-width: ${({ theme }) => theme.breakpoints.values.md}px) {
     font-size: ${({ theme }) => theme.typography.h2.fontSize};
   }
 
@@ -85,20 +82,24 @@ const StyledDemoBox = styled('div')`
   background-color: ${({ theme }) => theme.palette.background.default};
   border-radius: ${({ theme }) => theme.shape.borderRadius};
   border: 1px solid ${({ theme }) => theme.palette.grey[200]};
-  box-shadow: 0 0 12px 8px hsla(220, 25%, 80%, 0.2);
+  box-shadow: 0 0 12px 8px ${({ theme }) => theme.shadows[4]};
   background-image: url('/demo-image.png');
   background-size: cover;
   background-position: center;
 
   @media (min-width: ${({ theme }) => theme.breakpoints.values.sm}px) {
-    width: 900px;
-    height: 530px;
+    width: 90%;
+    height: auto;
+    aspect-ratio: 16 / 9;
     margin-top: ${({ theme }) => theme.spacing(10)};
   }
 
-  @media (max-width: ${({ theme }) => theme.breakpoints.values.xs}px) {
-    width: 700px;
-    height: 530px;
+  @media (max-width: ${({ theme }) => theme.breakpoints.values.sm}px) {
+    width: 90%;
+    max-width: 700px;
+    height: auto;
+    aspect-ratio: 16 / 9;
+    margin-top: ${({ theme }) => theme.spacing(7)};
   }
 `;
 


### PR DESCRIPTION
Several issues were fixed in the updated _**Hero Section**_:

- The **image** can be showed when switching to the mobile size (smaller than 600px width)
- The **Heading** part is now showing complete content under the mobile size with a _overflow-wrap_.
- The **button** is imported from the global Commonbtn.

The overall updated view can be find attached below:

![image](https://github.com/user-attachments/assets/88630447-14b6-49d4-820a-58841e2ea50e)