### PR TITLE
feat: DIS-58-Pricing-Page

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
-    "@mui/icons-material": "^6.4.11",
     "@mui/material": "^6.4.11",
     "@mui/system": "^7.0.2",
     "axios": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "@mui/icons-material": "^7.1.0",
     "@mui/material": "^6.4.11",
     "@mui/system": "^7.0.2",
     "axios": "^1.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@emotion/styled':
         specifier: ^11.14.0
         version: 11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0)
-      '@mui/icons-material':
-        specifier: ^6.4.11
-        version: 6.4.11(@mui/material@6.4.11(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.2)(react@19.1.0)
       '@mui/material':
         specifier: ^6.4.11
         version: 6.4.11(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -387,17 +384,6 @@ packages:
 
   '@mui/core-downloads-tracker@6.4.11':
     resolution: {integrity: sha512-CzAQs9CTzlwbsF9ZYB4o4lLwBv1/qNE264NjuYao+ctAXsmlPtYa8RtER4UsUXSMxNN9Qi+aQdYcKl2sUpnmAw==}
-
-  '@mui/icons-material@6.4.11':
-    resolution: {integrity: sha512-+jjJGIrB1awNbMv4ZVPPdN/p7O1UKFZ+xqRvNIQ8B1KnlID5hPMPBLM6UUbRF4bu3UDCbu79rn9Nye5LGNzmeA==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@mui/material': ^6.4.11
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
 
   '@mui/material@6.4.11':
     resolution: {integrity: sha512-k2D3FLJS+/qD0qnd6ZlAjGFvaaxe1Dl10NyvpeDzIebMuYdn8VqYe6XBgGueEAtnzSJM4V03VD9kb5Fi24dnTA==}
@@ -2505,14 +2491,6 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.0
 
   '@mui/core-downloads-tracker@6.4.11': {}
-
-  '@mui/icons-material@6.4.11(@mui/material@6.4.11(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.2)(react@19.1.0)':
-    dependencies:
-      '@babel/runtime': 7.27.0
-      '@mui/material': 6.4.11(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-    optionalDependencies:
-      '@types/react': 19.1.2
 
   '@mui/material@6.4.11(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@emotion/styled':
         specifier: ^11.14.0
         version: 11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0)
+      '@mui/icons-material':
+        specifier: ^7.1.0
+        version: 7.1.0(@mui/material@6.4.11(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.2)(react@19.1.0)
       '@mui/material':
         specifier: ^6.4.11
         version: 6.4.11(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -99,6 +102,10 @@ packages:
 
   '@babel/runtime@7.27.0':
     resolution: {integrity: sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.27.1':
+    resolution: {integrity: sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.0':
@@ -384,6 +391,17 @@ packages:
 
   '@mui/core-downloads-tracker@6.4.11':
     resolution: {integrity: sha512-CzAQs9CTzlwbsF9ZYB4o4lLwBv1/qNE264NjuYao+ctAXsmlPtYa8RtER4UsUXSMxNN9Qi+aQdYcKl2sUpnmAw==}
+
+  '@mui/icons-material@7.1.0':
+    resolution: {integrity: sha512-1mUPMAZ+Qk3jfgL5ftRR06ATH/Esi0izHl1z56H+df6cwIlCWG66RXciUqeJCttbOXOQ5y2DCjLZI/4t3Yg3LA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@mui/material': ^7.1.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@mui/material@6.4.11':
     resolution: {integrity: sha512-k2D3FLJS+/qD0qnd6ZlAjGFvaaxe1Dl10NyvpeDzIebMuYdn8VqYe6XBgGueEAtnzSJM4V03VD9kb5Fi24dnTA==}
@@ -2207,6 +2225,8 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.14.1
 
+  '@babel/runtime@7.27.1': {}
+
   '@babel/template@7.27.0':
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -2491,6 +2511,14 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.0
 
   '@mui/core-downloads-tracker@6.4.11': {}
+
+  '@mui/icons-material@7.1.0(@mui/material@6.4.11(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.2)(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@mui/material': 6.4.11(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.2
 
   '@mui/material@6.4.11(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react@19.1.0))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:

--- a/src/app/pricing/components/PricingCard.tsx
+++ b/src/app/pricing/components/PricingCard.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { styled } from '@mui/material/styles';
+
+import CommonButton from '@/components/ui/CommonButton';
+import { PlanButton } from '@/types/plan.types';
+
+interface PricingCardProps {
+  features: {
+    callMinutes: string;
+    support: string;
+  };
+  pricing: { priceDisplay: string; periodDisplay: string };
+  buttons: PlanButton[];
+}
+
+function CustomCheckIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="8"
+        cy="8"
+        r="6.2"
+        stroke="#6d6d6d"
+        strokeWidth="1.6"
+        fill="none"
+      />
+      <path
+        d="M5.6 8L7.2 9.6L10.4 6.8"
+        stroke="#6d6d6d"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+const CardContainer = styled('div')(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '100%',
+  maxWidth: '448px',
+  minWidth: '280px',
+  minHeight: '458px',
+  height: 'auto',
+  padding: '30px',
+  borderRadius: '24px',
+  border: '1px solid #d5d5d5',
+  backgroundColor: '#fff',
+}));
+
+const PriceRow = styled('div')(() => ({
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: '10px',
+  margin: '96px 0 40px 0', 
+}));
+
+const PriceText = styled('span')(() => ({
+  fontFamily: 'DINAlternate, sans-serif',
+  fontSize: '48px',
+  fontWeight: 'bold',
+  color: '#060606',
+  lineHeight: 1,
+}));
+
+const PeriodText = styled('span')(() => ({
+  fontFamily: 'Roboto, sans-serif',
+  fontSize: '16px',
+  fontWeight: 400,
+  lineHeight: 1.25,
+  color: '#060606',
+  marginTop: '18px', 
+}));
+
+const BtnContainer = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexWrap: 'wrap',
+  justifyContent: 'center',
+  marginBottom: '40px',
+
+  [theme.breakpoints.up('lg')]: {
+    flexWrap: 'nowrap', 
+  },
+}));
+
+const FeatureItem = styled('div')({
+  display: 'flex',
+  alignItems: 'center',
+  marginBottom: '16px',
+});
+
+const IconWrapper = styled('div')({
+  width: '20px',
+  height: '20px',
+  padding: '2px',
+  marginRight: '12px',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+});
+
+const FeatureLabel = styled('span')({
+  fontFamily: 'Roboto',
+  fontSize: '14px',
+  color: '#6d6d6d',
+  margin: '2px 8px 2px 0px',
+});
+
+const FeatureValue = styled('span')({
+  fontFamily: 'Roboto',
+  fontSize: '14px',
+  color: '#060606',
+  margin: '2px 0 2px 0px',
+});
+
+export default function PricingCard({  features, pricing, buttons }: PricingCardProps) {
+  return (
+    <CardContainer>
+      <PriceRow>
+        <PriceText>
+          {pricing.priceDisplay}
+        </PriceText>
+        <PeriodText>
+          {pricing.periodDisplay}
+        </PeriodText>
+      </PriceRow>
+      <BtnContainer>
+        {buttons.map((btn, i) => (
+          <CommonButton
+            key={i}
+            buttonVariant={btn.variant === 'primary' ? 'black' : 'green'}
+            sx={{
+              width: '388px',
+              height: '48px',
+            }}
+          >
+            {btn.label}
+          </CommonButton>
+        ))}
+      </BtnContainer>
+
+      <FeatureItem>
+        <IconWrapper><CustomCheckIcon /></IconWrapper>
+        <FeatureLabel>Call Minutes:</FeatureLabel>
+        <FeatureValue>{features.callMinutes}</FeatureValue>
+      </FeatureItem>
+
+      <FeatureItem>
+        <IconWrapper><CustomCheckIcon /></IconWrapper>
+        <FeatureLabel>Support:</FeatureLabel>
+        <FeatureValue>{features.support}</FeatureValue>
+      </FeatureItem>
+    </CardContainer>
+  );
+}

--- a/src/app/pricing/components/PricingSection.tsx
+++ b/src/app/pricing/components/PricingSection.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { styled } from '@mui/material/styles';
+import React, { useEffect, useState } from 'react';
+
+import { Plan, PlanButton } from '@/types/plan.types';
+import axios from '@/utils/axios';
+
+import PricingCard from './PricingCard';
+
+function getButtons(tier: Plan['tier']): PlanButton[] {
+  switch (tier) {
+    case 'FREE':
+      return [{ label: 'Try for Free', variant: 'primary' }];
+    case 'BASIC':
+      return [
+        { label: 'Get Basic', variant: 'primary' },
+        ];
+    case 'PRO':
+      return [
+        { label: 'Go Pro', variant: 'primary' },
+      ];
+  }
+}
+
+function parseRRule(rrule: string): string {
+  if (rrule.includes('FREQ=MONTHLY;INTERVAL=3')) return 'quarter';
+  if (rrule.includes('FREQ=MONTHLY')) return 'month';
+  if (rrule.includes('FREQ=YEARLY')) return 'year';
+  return '';
+}
+
+function getPrice(pricing: { rrule: string; price: number }[]): { priceDisplay: string; periodDisplay: string } {
+  const matched = pricing[0];
+
+  if (!matched) {
+    return { priceDisplay: '--', periodDisplay: '' };
+  }
+
+  if (matched.price === 0) {
+    return { priceDisplay: 'FREE', periodDisplay: '' };
+  }
+
+  return {
+    priceDisplay: `$${matched.price}`,
+    periodDisplay: ` /${parseRRule(matched.rrule)}`,
+  };
+}
+
+const PricingContainer = styled('section')(({ theme }) => ({
+  padding: "128px 0 68px 0",
+  textAlign: 'center',
+  backgroundColor: theme.palette.background.default,
+}));
+
+const SectionTitle = styled('h2')(({ theme }) => ({
+  ...theme.typography.h2,
+  textAlign: 'center',
+  margin: '0 0 80px',
+}));
+
+
+const PlanGrid = styled('div')(({ theme }) => ({
+  display: 'flex',
+  flexWrap: 'nowrap',
+  overflowX: 'auto',
+  gap: theme.spacing(2),
+  padding: `0 ${theme.spacing(2)}px`,
+  scrollSnapType: 'x mandatory',
+  WebkitOverflowScrolling: 'touch',
+}));
+
+export default function PricingSection() {
+  const [plans, setPlans] = useState<Plan[]>([]);
+
+  useEffect(() => {
+    const fetchPlans = async () => {
+      try {
+        const res = await axios.get('api/plan'); 
+        setPlans(res.data);
+      } catch (err) {
+        console.error('Failed to fetch plans:', err);
+      }
+    };
+
+    fetchPlans();
+  }, []);
+
+  return (
+    <PricingContainer>
+      <SectionTitle>Choose the Right Plan for You</SectionTitle>
+      <PlanGrid>
+      {plans.map((plan) => (
+        <PricingCard
+        key={plan._id}
+        features={plan.features}
+        pricing={getPrice(plan.pricing)}
+        buttons={getButtons(plan.tier)}
+        />
+      ))}
+      </PlanGrid>
+    </PricingContainer>
+  );
+}

--- a/src/app/pricing/layout.tsx
+++ b/src/app/pricing/layout.tsx
@@ -1,0 +1,13 @@
+import MainLayout from "@/components/layout/main-layout";
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <MainLayout>
+        {children}
+    </MainLayout>
+  );
+}

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,0 +1,9 @@
+import PricingSection from "./components/PricingSection";
+
+export default function Pricing() {
+  return (
+    <>
+      <PricingSection />
+    </>
+  );
+}


### PR DESCRIPTION
## ✨ Summary

This PR adds a fully responsive **Pricing Page**, including:

- Layout structure for Plan cards (`Free`, `Basic`, `Pro`)
- Support for dynamic pricing via `pricing[]` array from backend
- Common button styling using `CommonButton` component

---

## 🔧 What's Implemented

- `PlanCard` and `PlanCardSection` components
- Responsive UI structure based on provided Zeplin design
- Reusable `getPrice()` helper to extract price/period
- Custom check icon rendering (SVG) for accurate visual match
- Feature list styling using precise spacing and color tokens
- Section title (`Choose the Right Plan`) implementation

---

## 📸 Screenshots
![image](https://github.com/user-attachments/assets/06209509-00a6-43fc-9205-7702dc4c8d16)
