### PR TITLE
Bugfix2/dis 32 landing page footer responsiveness

### DIFF
--- a/src/components/layout/main-layout/Footer.tsx
+++ b/src/components/layout/main-layout/Footer.tsx
@@ -102,7 +102,7 @@ const CopyrightText = styled(Typography)(({ theme }) => ({
 const NavLinksBox = styled(Box)(({ theme }) => ({
   flex: 7,
   display: 'none',
-  [theme.breakpoints.up('lg')]: {
+  [theme.breakpoints.up('xl')]: {
     display: 'block',
   },
 }));

--- a/src/components/layout/main-layout/Footer.tsx
+++ b/src/components/layout/main-layout/Footer.tsx
@@ -66,6 +66,7 @@ const SocialBox = styled(Box)(({ theme }) => ({
 const SocialText = styled(Typography)(({ theme }) => ({
   color: theme.palette.text.secondary,
   textAlign: 'center',
+  whiteSpace: 'nowrap',
   [theme.breakpoints.up('sm')]: {
     textAlign: 'left',
     marginRight: theme.spacing(1),
@@ -110,6 +111,7 @@ const NavLinksStack = styled(Stack)(({ theme }) => ({
   flexDirection: 'row',
   marginRight: theme.spacing(2),
   gap: theme.spacing(5),
+  whiteSpace: 'nowrap',
 }));
 
 const NavLink = styled(Link)(({ theme }) => ({


### PR DESCRIPTION
This PR addresses layout issues in the footer by implementing the following changes:

1. Applied noWrap to all Navi link titles and social text headings to prevent unwanted line breaks.
3. Restricted Navi links display to screens wider than xl to avoid horizontal overflow caused by noWrap.

