### PR TITLE
Updated navibar font, logo and spacing

### DIFF
--- a/src/components/layout/main-layout/Navbar.tsx
+++ b/src/components/layout/main-layout/Navbar.tsx
@@ -24,12 +24,12 @@ import { MobileDrawer } from './navbar/MobileDrawer';
 import { NavItemProps } from './navbar/NavItem';
 
 const navItems: NavItemProps[] = [
-  { href: '/', text: 'Home', width: 75, textWidth: 43 },
-  { href: '/products', text: 'Products', width: 98, textWidth: 66 },
-  { href: '/pricing', text: 'Pricing', width: 83, textWidth: 51 },
-  { href: '/blogs', text: 'Blogs', width: 73, textWidth: 41 },
-  { href: '/features', text: 'Features', width: 95, textWidth: 63 },
-  { href: '/about', text: 'About Us', width: 98, textWidth: 66 },
+  { href: '/', text: 'Home', width: 70, textWidth: 38 },
+  { href: '/products', text: 'Products', width: 90, textWidth: 58 },
+  { href: '/pricing', text: 'Pricing', width: 77, textWidth: 45 },
+  { href: '/blogs', text: 'Blogs', width: 68, textWidth: 36 },
+  { href: '/features', text: 'Features', width: 87, textWidth: 55 },
+  { href: '/about', text: 'About Us', width: 90, textWidth: 58 },
 ];
 
 const StyledAppBar = styled(AppBar)(({ theme }) => ({
@@ -37,7 +37,7 @@ const StyledAppBar = styled(AppBar)(({ theme }) => ({
   top: 0,
   left: 0,
   right: 0,
-  height: 80,
+  height: 72,
   marginBottom: '0',
   zIndex: theme.zIndex.drawer + 1,
 }));
@@ -47,7 +47,7 @@ const StyledToolbar = styled(Toolbar)(() => ({
   maxWidth: '1920px',
   display: 'flex',
   justifyContent: 'space-between',
-  height: '80px',
+  height: '72px',
   transition: 'padding 0.3s ease',
 }));
 
@@ -112,8 +112,8 @@ export default function Navbar({ variant = 'light' }: NavbarProps) {
                 <Image
                   src={variant === 'light' ? "/logo.svg" : "/logo-dark.svg"}
                   alt="Dispatch AI logo"
-                  width={152}
-                  height={36}
+                  width={126}
+                  height={30}
                   priority
                   style={{ cursor: 'pointer', display: 'block' }}
                 />

--- a/src/components/layout/main-layout/navbar/AuthButton.tsx
+++ b/src/components/layout/main-layout/navbar/AuthButton.tsx
@@ -13,15 +13,11 @@ interface AuthButtonProps {
 
 const BaseAuthButton = styled(CommonButton, {
   shouldForwardProp: (prop) => !['isMobile', 'themeVariant'].includes(prop as string),
-})<{ isMobile?: boolean; themeVariant?: 'light' | 'dark' }>(({ isMobile }) => ({
-  '&&': { 
-    fontSize: isMobile ? 20 : 16,
-    fontWeight: 'bold',
-  },
-  padding: isMobile ? '12px 24px' : '8px 16px',
-  borderRadius: 12,
-  textTransform: 'none',
-}));
+})<{ isMobile?: boolean; themeVariant?: 'light' | 'dark' }>(
+  ({ isMobile }) => ({
+    ...(isMobile ? { fontSize: 20, fontWeight: 'bold', padding: '12px 24px' } : {}),
+  })
+);
 
 const LoginButton = styled(BaseAuthButton)(({ theme, themeVariant = 'light' }) => ({
   backgroundColor: themeVariant === 'light' ? theme.palette.background.default : '#060606',

--- a/src/components/layout/main-layout/navbar/DesktopNavItems.tsx
+++ b/src/components/layout/main-layout/navbar/DesktopNavItems.tsx
@@ -10,14 +10,10 @@ interface DesktopNavItemsProps {
   themeVariant?: 'light' | 'dark';
 }
 
-const DesktopNavContainer = styled(Stack)(({ theme }) => ({
+const DesktopNavContainer = styled(Stack)(() => ({
   flex: 1,
   justifyContent: 'center',
   alignItems: 'center',
-  marginLeft: theme.spacing(3.5),
-  [theme.breakpoints.down('lg')]: {
-    marginLeft: theme.spacing(2),
-  },
 }));
 
 export function DesktopNavItems({ navItems, themeVariant = 'light' }: DesktopNavItemsProps) {

--- a/src/components/layout/main-layout/navbar/NavItem.tsx
+++ b/src/components/layout/main-layout/navbar/NavItem.tsx
@@ -4,7 +4,6 @@ import type { BoxProps } from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
 import NextLink, { LinkProps } from 'next/link';
 
-
 interface ExtraNavProps {
   width: number;
   textWidth: number;
@@ -48,22 +47,19 @@ const NavItemContainer = styled(Box, {
 }));
 
 const NavItemText = styled(Typography, {
-  shouldForwardProp: (prop) => !['textWidth', 'themeVariant', 'isMobile'].includes(prop as string),
+  shouldForwardProp: (prop) =>
+     !['textWidth', 'themeVariant', 'isMobile'].includes(prop as string),
 })<{ textWidth: number; themeVariant?: 'light' | 'dark'; isMobile?: boolean }>(
   ({ theme, textWidth, themeVariant = 'light', isMobile }) => ({
     width: isMobile ? 'auto' : textWidth,
-    height: isMobile ? 24 : 20,
-    '&&': { 
-      fontSize: isMobile ? 20 : 16,
-      fontWeight: isMobile ? 500 : 400,
-      whiteSpace: 'nowrap',
-    },
+    height: isMobile ? 24 : undefined,
     lineHeight: 1.25,
+    whiteSpace: 'nowrap',
     color: themeVariant === 'light' ? theme.palette.text.primary : '#ffffff',
-    [theme.breakpoints.down('lg')]: {
-      fontSize: 14,
-      width: 'auto',
-    },
+    ...(isMobile && {
+      fontSize: 20,
+      fontWeight: 500,
+    }),
   })
 );
 
@@ -83,13 +79,14 @@ export function NavItem({
       width={width}
       textWidth={textWidth}
       themeVariant={themeVariant}
+      isMobile={isMobile}
       onClick={() => handleDrawerToggle?.()}
     >
-      <NavItemText 
-        textWidth={textWidth} 
-        themeVariant={themeVariant} 
-        variant="body2"
+      <NavItemText
+        textWidth={textWidth}
+        themeVariant={themeVariant}
         isMobile={isMobile}
+        variant="body1"
       >
         {text}
       </NavItemText>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4d419a86-5970-4f58-9bf1-b594c7e91b9c)
**Updated the navbar’s fonts, logo, and spacing to match the latest Zeplin design.**