### PR TITLE
Fix signup redirect path

### DIFF
--- a/src/app/(public)/signup/component/SignupForm.tsx
+++ b/src/app/(public)/signup/component/SignupForm.tsx
@@ -79,7 +79,7 @@ export default function SignupForm() {
 
   useEffect(() => {
     if (token) {
-      router.replace('/dashboard');
+      router.replace('/admin/overview');
     }
   }, [token, router]);
 


### PR DESCRIPTION
Changed the redirect path after successful signup from `/dashboard` to `/admin/overview`