### PR TITLE
bugfix/privacy and terms on signup page

### DIFF
--- a/src/app/(public)/blogs/components/BlogList.tsx
+++ b/src/app/(public)/blogs/components/BlogList.tsx
@@ -36,7 +36,7 @@ export default function BlogList() {
   const topic = searchParams.get('topic') ?? '';
   const limit = 9;
   const page = Number(searchParams.get('page') ?? '1');
-  const [total, setTotal] = useState(0);
+  const [, setTotal] = useState(0);
 
   useEffect(() => {
     const fetchBlogs = async () => {

--- a/src/app/(public)/blogs/page.tsx
+++ b/src/app/(public)/blogs/page.tsx
@@ -34,6 +34,7 @@ export default function BlogsPage() {
         setHighlightBlogs(res.data);
       } catch (error) {
         if (!axios.isCancel(error)) {
+          // eslint-disable-next-line no-console
           console.error('Failed to fetch highlight blogs:', error);
         }
       }

--- a/src/app/(public)/privacy/page.tsx
+++ b/src/app/(public)/privacy/page.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { Box } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+const PageContainer = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  flexDirection: 'column',
+  backgroundColor: theme.palette.background.default,
+  paddingTop: theme.spacing(10),
+  paddingBottom: theme.spacing(7),
+  color: theme.palette.text.primary,
+  minHeight: '100vh',
+}));
+
+const ContentContainer = styled(Box)(({ theme }) => ({
+  maxWidth: '800px',
+  width: '100%',
+  padding: theme.spacing(0, 3),
+  textAlign: 'left',
+}));
+
+const PageTitle = styled('h1')(({ theme }) => ({
+  textAlign: 'center',
+  color: theme.palette.text.primary,
+  fontSize: theme.typography.h1.fontSize,
+  fontFamily: theme.typography.h1.fontFamily,
+  fontWeight: theme.typography.h1.fontWeight,
+  marginBottom: theme.spacing(6),
+}));
+
+const SectionTitle = styled('h2')(({ theme }) => ({
+  color: theme.palette.text.primary,
+  fontSize: theme.typography.h3.fontSize,
+  fontFamily: theme.typography.h3.fontFamily,
+  fontWeight: theme.typography.h3.fontWeight,
+  marginTop: theme.spacing(4),
+  marginBottom: theme.spacing(2),
+}));
+
+const SectionText = styled('p')(({ theme }) => ({
+  color: theme.palette.text.primary,
+  fontSize: theme.typography.body1.fontSize,
+  fontFamily: theme.typography.fontFamily,
+  lineHeight: 1.6,
+  marginBottom: theme.spacing(2),
+}));
+
+const IntroText = styled('p')(({ theme }) => ({
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+  fontSize: theme.typography.body1.fontSize,
+  fontFamily: theme.typography.fontFamily,
+  lineHeight: 1.6,
+  marginBottom: theme.spacing(4),
+  fontStyle: 'italic',
+}));
+
+const List = styled('ul')(({ theme }) => ({
+  color: theme.palette.text.primary,
+  fontSize: theme.typography.body1.fontSize,
+  fontFamily: theme.typography.fontFamily,
+  lineHeight: 1.6,
+  marginBottom: theme.spacing(2),
+  paddingLeft: theme.spacing(3),
+}));
+
+const ListItem = styled('li')(({ theme }) => ({
+  marginBottom: theme.spacing(1),
+}));
+
+const ContactInfo = styled(Box)(({ theme }) => ({
+  backgroundColor: theme.palette.grey[50],
+  border: `1px solid ${theme.palette.grey[200]}`,
+  borderRadius: theme.shape.borderRadius,
+  padding: theme.spacing(3),
+  marginTop: theme.spacing(4),
+  textAlign: 'center',
+}));
+
+const HighlightText = styled('p')(({ theme }) => ({
+  color: theme.palette.text.primary,
+  fontSize: theme.typography.body1.fontSize,
+  fontFamily: theme.typography.fontFamily,
+  fontWeight: 'bold',
+  textAlign: 'center',
+  marginTop: theme.spacing(2),
+  marginBottom: theme.spacing(2),
+  padding: theme.spacing(1),
+  borderLeft: `4px solid ${theme.palette.text.primary}`,
+  paddingLeft: theme.spacing(2),
+  fontStyle: 'italic',
+  backgroundColor: 'transparent',
+}));
+
+export default function PrivacyPage() {
+  return (
+    <PageContainer>
+      <ContentContainer>
+        <PageTitle>Privacy Policy</PageTitle>
+        <IntroText>
+          Dispatch AI respects your privacy. This Privacy Policy explains how we
+          collect, use, disclose, and safeguard your information when you use
+          our Service.
+        </IntroText>
+
+        <SectionTitle>Information We Collect</SectionTitle>
+        <List>
+          <ListItem>
+            <strong>Personal Information:</strong> such as name, email, phone
+            number, and payment details.
+          </ListItem>
+          <ListItem>
+            <strong>Call Data:</strong> including call recordings, transcripts,
+            AI responses, and call metadata.
+          </ListItem>
+          <ListItem>
+            <strong>Usage Data:</strong> including pages visited, time spent,
+            and actions taken in the dashboard.
+          </ListItem>
+        </List>
+
+        <SectionTitle>How We Use Your Information</SectionTitle>
+        <List>
+          <ListItem>To deliver and improve our Service.</ListItem>
+          <ListItem>To provide customer support.</ListItem>
+          <ListItem>
+            To communicate important updates or promotional materials (with your
+            consent).
+          </ListItem>
+          <ListItem>To comply with legal obligations.</ListItem>
+        </List>
+
+        <SectionTitle>Data Storage and Security</SectionTitle>
+        <HighlightText>
+          Data is stored securely in Australia using trusted cloud providers
+        </HighlightText>
+        <List>
+          <ListItem>
+            We use encryption, access control, and regular audits to protect
+            your data.
+          </ListItem>
+          <ListItem>
+            Your information is processed and stored in compliance with
+            Australian privacy laws.
+          </ListItem>
+        </List>
+
+        <SectionTitle>Sharing of Information</SectionTitle>
+        <HighlightText>We do not sell your data</HighlightText>
+        <List>
+          <ListItem>
+            Data may be shared with third-party processors (e.g., email, payment
+            gateways) only as necessary to deliver the Service.
+          </ListItem>
+          <ListItem>
+            We may disclose data when required by law or to protect our legal
+            rights.
+          </ListItem>
+        </List>
+
+        <SectionTitle>Your Rights</SectionTitle>
+        <List>
+          <ListItem>
+            You can access, update, or delete your personal information from
+            your account settings.
+          </ListItem>
+          <ListItem>
+            You may request a copy of your data or ask us to delete it by
+            contacting us.
+          </ListItem>
+          <ListItem>
+            You have the right to withdraw consent for marketing communications
+            at any time.
+          </ListItem>
+        </List>
+
+        <SectionTitle>Cookies</SectionTitle>
+        <SectionText>
+          Our site uses cookies to enhance user experience and analytics. You
+          may control cookie settings through your browser preferences.
+        </SectionText>
+
+        <SectionTitle>Data Retention</SectionTitle>
+        <SectionText>
+          We retain data only as long as necessary to provide the Service or
+          comply with legal obligations. You may request deletion of your data
+          at any time.
+        </SectionText>
+
+        <SectionTitle>Children's Privacy</SectionTitle>
+        <SectionText>
+          Our Service is not intended for children under 18 years of age. We do
+          not knowingly collect personal information from children under 18.
+        </SectionText>
+
+        <SectionTitle>Changes to This Policy</SectionTitle>
+        <SectionText>
+          We may update this policy from time to time. Changes will be notified
+          via email or dashboard notification. Continued use of our Service
+          after changes constitutes acceptance of the updated policy.
+        </SectionText>
+
+        <ContactInfo>
+          <SectionTitle style={{ marginTop: 0 }}>Contact Us</SectionTitle>
+          <SectionText style={{ marginBottom: 0 }}>
+            If you have any questions about this Privacy Policy, please contact
+            us at <strong>privacy@dispatchai.com.au</strong>
+          </SectionText>
+        </ContactInfo>
+      </ContentContainer>
+    </PageContainer>
+  );
+}

--- a/src/app/(public)/terms/page.tsx
+++ b/src/app/(public)/terms/page.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { Box } from '@mui/material';
+import { styled } from '@mui/material/styles';
+
+const PageContainer = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  flexDirection: 'column',
+  backgroundColor: theme.palette.background.default,
+  paddingTop: theme.spacing(10),
+  paddingBottom: theme.spacing(7),
+  color: theme.palette.text.primary,
+  minHeight: '100vh',
+}));
+
+const ContentContainer = styled(Box)(({ theme }) => ({
+  maxWidth: '800px',
+  width: '100%',
+  padding: theme.spacing(0, 3),
+  textAlign: 'left',
+}));
+
+const PageTitle = styled('h1')(({ theme }) => ({
+  textAlign: 'center',
+  color: theme.palette.text.primary,
+  fontSize: theme.typography.h1.fontSize,
+  fontFamily: theme.typography.h1.fontFamily,
+  fontWeight: theme.typography.h1.fontWeight,
+  marginBottom: theme.spacing(6),
+}));
+
+const SectionTitle = styled('h2')(({ theme }) => ({
+  color: theme.palette.text.primary,
+  fontSize: theme.typography.h3.fontSize,
+  fontFamily: theme.typography.h3.fontFamily,
+  fontWeight: theme.typography.h3.fontWeight,
+  marginTop: theme.spacing(4),
+  marginBottom: theme.spacing(2),
+}));
+
+const SectionText = styled('p')(({ theme }) => ({
+  color: theme.palette.text.primary,
+  fontSize: theme.typography.body1.fontSize,
+  fontFamily: theme.typography.fontFamily,
+  lineHeight: 1.6,
+  marginBottom: theme.spacing(2),
+}));
+
+const IntroText = styled('p')(({ theme }) => ({
+  textAlign: 'center',
+  color: theme.palette.text.secondary,
+  fontSize: theme.typography.body1.fontSize,
+  fontFamily: theme.typography.fontFamily,
+  lineHeight: 1.6,
+  marginBottom: theme.spacing(4),
+  fontStyle: 'italic',
+}));
+
+const List = styled('ul')(({ theme }) => ({
+  color: theme.palette.text.primary,
+  fontSize: theme.typography.body1.fontSize,
+  fontFamily: theme.typography.fontFamily,
+  lineHeight: 1.6,
+  marginBottom: theme.spacing(2),
+  paddingLeft: theme.spacing(3),
+}));
+
+const ListItem = styled('li')(({ theme }) => ({
+  marginBottom: theme.spacing(1),
+}));
+
+const ContactInfo = styled(Box)(({ theme }) => ({
+  backgroundColor: theme.palette.grey[50],
+  border: `1px solid ${theme.palette.grey[200]}`,
+  borderRadius: theme.shape.borderRadius,
+  padding: theme.spacing(3),
+  marginTop: theme.spacing(4),
+  textAlign: 'center',
+}));
+
+export default function TermsPage() {
+  return (
+    <PageContainer>
+      <ContentContainer>
+        <PageTitle>Terms of Service</PageTitle>
+        <IntroText>
+          Welcome to Dispatch AI! These Terms of Service govern your access to
+          and use of our services. By using Dispatch AI, you agree to be bound
+          by these Terms.
+        </IntroText>
+
+        <SectionTitle>Use of the Service</SectionTitle>
+        <List>
+          <ListItem>
+            You must be at least 18 years old to use the Service.
+          </ListItem>
+          <ListItem>
+            You agree to use the Service only for lawful purposes and in
+            accordance with these Terms.
+          </ListItem>
+          <ListItem>
+            Dispatch AI grants you a limited, non-exclusive, non-transferable
+            license to use the Service.
+          </ListItem>
+        </List>
+
+        <SectionTitle>User Accounts</SectionTitle>
+        <List>
+          <ListItem>
+            You are responsible for maintaining the confidentiality of your
+            account credentials.
+          </ListItem>
+          <ListItem>
+            You agree to provide accurate and up-to-date information.
+          </ListItem>
+          <ListItem>
+            You are responsible for all activities under your account.
+          </ListItem>
+        </List>
+
+        <SectionTitle>AI Call Handling and Automation</SectionTitle>
+        <List>
+          <ListItem>
+            Our AI assistant handles calls, creates tasks, and communicates on
+            your behalf based on predefined logic and user settings.
+          </ListItem>
+          <ListItem>
+            You acknowledge that while we strive for accuracy, AI interactions
+            may not always be perfect and should be monitored regularly.
+          </ListItem>
+        </List>
+
+        <SectionTitle>Subscription Plans and Billing</SectionTitle>
+        <List>
+          <ListItem>
+            Dispatch AI offers Free, Basic, and Pro plans. Details of each plan
+            are available on our website.
+          </ListItem>
+          <ListItem>
+            By subscribing to a paid plan, you agree to pay the applicable fees.
+          </ListItem>
+          <ListItem>
+            You may cancel, upgrade, or downgrade your plan at any time, with
+            changes taking effect based on our billing cycle.
+          </ListItem>
+        </List>
+
+        <SectionTitle>Prohibited Activities</SectionTitle>
+        <List>
+          <ListItem>
+            You may not use the Service for illegal activities, spamming, or to
+            infringe on the rights of others.
+          </ListItem>
+          <ListItem>
+            You may not reverse engineer, copy, or distribute the Service or its
+            components.
+          </ListItem>
+        </List>
+
+        <SectionTitle>Termination</SectionTitle>
+        <List>
+          <ListItem>
+            We reserve the right to suspend or terminate your access if you
+            violate these Terms.
+          </ListItem>
+          <ListItem>
+            You may cancel your account at any time from your settings.
+          </ListItem>
+        </List>
+
+        <SectionTitle>Limitation of Liability</SectionTitle>
+        <SectionText>
+          Dispatch AI is provided on an "as-is" and "as-available" basis. We are
+          not liable for indirect, incidental, or consequential damages arising
+          from your use of the Service.
+        </SectionText>
+
+        <SectionTitle>Governing Law</SectionTitle>
+        <SectionText>
+          These Terms are governed by the laws of New South Wales, Australia.
+        </SectionText>
+
+        <ContactInfo>
+          <SectionTitle style={{ marginTop: 0 }}>Contact Us</SectionTitle>
+          <SectionText style={{ marginBottom: 0 }}>
+            If you have any questions about these Terms, please contact us at{' '}
+            <strong>support@dispatchai.com.au</strong>
+          </SectionText>
+        </ContactInfo>
+      </ContentContainer>
+    </PageContainer>
+  );
+}


### PR DESCRIPTION
Added privacy and terms content on signup page.

<img width="675" height="530" alt="image" src="https://github.com/user-attachments/assets/d3b06796-ffef-471c-85c9-12d2f51aed1b" />

The hyperlinks on signup page will direct users to terms and privacy pages.
<img width="895" height="504" alt="image" src="https://github.com/user-attachments/assets/a0f1a505-4b74-4437-a080-ebbf5db5e77b" />
<img width="891" height="610" alt="image" src="https://github.com/user-attachments/assets/d9199f86-c019-4c53-baee-f1807d7cd93d" />
