### PR TITLE
Bugfix/dis 131 mobile about us

### DIFF
--- a/src/app/(public)/about/components/AboutBanner.tsx
+++ b/src/app/(public)/about/components/AboutBanner.tsx
@@ -9,7 +9,6 @@ export const AboutHeader = styled(Box)(({ theme }) => ({
   padding: theme.spacing(10, 50),
   marginTop: theme.spacing(8),
   color: theme.palette.text.primary,
-  gap: theme.spacing(10),
   [theme.breakpoints.down('xl')]: {
     padding: theme.spacing(8, 20),
   },
@@ -29,7 +28,7 @@ export const HeaderContainer = styled(Container)(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  gap: theme.spacing(10),
+  gap: theme.spacing(4),
   [theme.breakpoints.down('sm')]: {
     padding: theme.spacing(1, 1),
     flexDirection: 'column-reverse',

--- a/src/app/(public)/about/components/AboutBanner.tsx
+++ b/src/app/(public)/about/components/AboutBanner.tsx
@@ -11,6 +11,7 @@ export const AboutHeader = styled(Box)(({ theme }) => ({
   color: theme.palette.text.primary,
   [theme.breakpoints.down('xl')]: {
     padding: theme.spacing(8, 20),
+    marginTop: theme.spacing(4),
   },
   [theme.breakpoints.down('sm')]: {
     padding: theme.spacing(5, 5),

--- a/src/app/(public)/about/components/CallToAction.tsx
+++ b/src/app/(public)/about/components/CallToAction.tsx
@@ -10,7 +10,7 @@ export const CallToActionText = styled('h3')(({ theme }) => ({
   fontSize: theme.typography.h3.fontSize,
   fontFamily: theme.typography.h3.fontFamily,
   fontWeight: theme.typography.h3.fontWeight,
-  margin: theme.spacing(1, 0, 5),
+  margin: 0,
 }));
 
 export const CallToActionTitle = styled('h2')(({ theme }) => ({
@@ -30,7 +30,7 @@ export const CallToActionWrapper = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.background.dark,
   padding: theme.spacing(10, 4),
   color: theme.palette.text.primary,
-  gap: theme.spacing(5),
+  gap: theme.spacing(3),
   [theme.breakpoints.down('sm')]: {
     padding: theme.spacing(4, 1),
   },

--- a/src/app/(public)/about/components/InfoBody.tsx
+++ b/src/app/(public)/about/components/InfoBody.tsx
@@ -22,7 +22,6 @@ export const SectionTitle = styled('h2')(({ theme }) => ({
   fontSize: theme.typography.h2.fontSize,
   fontFamily: theme.typography.h2.fontFamily,
   fontWeight: theme.typography.h2.fontWeight,
-  margin: theme.spacing(4, 0, 2),
 }));
 
 export const SectionWrapper = styled(Box)(({ theme }) => ({
@@ -30,7 +29,6 @@ export const SectionWrapper = styled(Box)(({ theme }) => ({
   alignItems: 'center',
   flexDirection: 'column',
   backgroundColor: theme.palette.background.default,
-  paddingTop: theme.spacing(10),
-  paddingBottom: theme.spacing(7),
+  paddingTop: theme.spacing(6),
   color: theme.palette.text.primary,
 }));

--- a/src/app/(public)/about/components/InfoBody.tsx
+++ b/src/app/(public)/about/components/InfoBody.tsx
@@ -7,8 +7,8 @@ export const SectionText = styled('p')(({ theme }) => ({
   fontSize: theme.typography.body1.fontSize,
   fontFamily: theme.typography.fontFamily,
   lineHeight: theme.spacing(3),
-  maxWidth: '60%',
-  marginBottom: theme.spacing(8),
+  maxWidth: '100%',
+  marginBottom: theme.spacing(6),
   [theme.breakpoints.up('sm')]: {
     fontSize: theme.typography.body2.fontSize,
   },

--- a/src/app/(public)/about/components/InfoBody.tsx
+++ b/src/app/(public)/about/components/InfoBody.tsx
@@ -7,10 +7,11 @@ export const SectionText = styled('p')(({ theme }) => ({
   fontSize: theme.typography.body1.fontSize,
   fontFamily: theme.typography.fontFamily,
   lineHeight: theme.spacing(3),
-  maxWidth: '100%',
+  maxWidth: '60%',
   marginBottom: theme.spacing(6),
-  [theme.breakpoints.up('sm')]: {
+  [theme.breakpoints.down('sm')]: {
     fontSize: theme.typography.body2.fontSize,
+    maxWidth: '100%',
   },
 }));
 

--- a/src/app/(public)/about/components/TeamCard.tsx
+++ b/src/app/(public)/about/components/TeamCard.tsx
@@ -46,7 +46,8 @@ export const TeamMemberImage = styled('div')<{ backgroundImage: string }>(
     backgroundImage: `url(${backgroundImage})`,
     [theme.breakpoints.down('sm')]: {
       width: '100%',
-      height: '200px',
+      aspectRatio: '1 / 1',
+      height: 'auto',
     },
   }),
 );


### PR DESCRIPTION
This pull request makes several adjustments to the layout and styling of the About and Call To Action sections to improve responsiveness and visual consistency across different screen sizes. The main changes include reducing spacing, adjusting padding and margins, and enhancing mobile responsiveness for text and images.

**Layout and Spacing Adjustments:**

* Reduced gaps and padding in `AboutBanner` components for better alignment and more compact layout. (`AboutHeader`, `HeaderContainer` in `AboutBanner.tsx`)
* Decreased gap and removed margin in `CallToAction` components to create a tighter, more unified appearance. (`CallToActionText`, `CallToActionWrapper` in `CallToAction.tsx`)
<img width="287" height="687" alt="image" src="https://github.com/user-attachments/assets/ebc39b9d-acc0-4b09-9901-d14cae83cec7" />
<img width="287" height="687" alt="image" src="https://github.com/user-attachments/assets/5357957b-9919-443d-abbb-9822270b3c17" />

**Mobile Responsiveness Improvements:**

* Improved text sizing and max width for `SectionText` on small screens, and reduced bottom margin for better readability on mobile devices. (`SectionText` in `InfoBody.tsx`)
* Adjusted padding and removed bottom padding in `SectionWrapper` for a more balanced section layout. (`SectionTitle`, `SectionWrapper` in `InfoBody.tsx`)
<img width="287" height="687" alt="image" src="https://github.com/user-attachments/assets/1b9beca9-76b4-42ea-a3d8-4cf82252fcb8" />

**Image Responsiveness:**

* Updated `TeamMemberImage` to use a square aspect ratio and automatic height on small screens, ensuring images scale appropriately on mobile devices. (`TeamMemberImage` in `TeamCard.tsx`)
<img width="210" height="392" alt="image" src="https://github.com/user-attachments/assets/44dd27dd-aab0-4b51-b34e-ba22081ad328" />
