### PR TITLE
Bugfix3/dis 131 mobile about us

### DIFF
--- a/src/app/(public)/about/components/InfoBody.tsx
+++ b/src/app/(public)/about/components/InfoBody.tsx
@@ -8,15 +8,19 @@ export const SectionText = styled('p')(({ theme }) => ({
   fontFamily: theme.typography.fontFamily,
   lineHeight: theme.spacing(3),
   maxWidth: '60%',
-  marginBottom: theme.spacing(6),
+  marginTop: theme.spacing(6),
+  marginBottom: '118px',
   [theme.breakpoints.down('sm')]: {
     fontSize: theme.typography.body2.fontSize,
     maxWidth: '100%',
+    marginTop: theme.spacing(3),
+    marginBottom: theme.spacing(6),
   },
 }));
 
 export const SectionTitle = styled('h2')(({ theme }) => ({
   display: 'flex',
+  margin: 0,
   flexDirection: 'column',
   alignItems: 'center',
   color: theme.palette.text.primary,
@@ -30,6 +34,9 @@ export const SectionWrapper = styled(Box)(({ theme }) => ({
   alignItems: 'center',
   flexDirection: 'column',
   backgroundColor: theme.palette.background.default,
-  paddingTop: theme.spacing(6),
+  paddingTop: '150px',
   color: theme.palette.text.primary,
+  [theme.breakpoints.down('sm')]: {
+    paddingTop: theme.spacing(6),
+  },
 }));


### PR DESCRIPTION
This pull request makes several style adjustments to the `InfoBody` component to improve layout consistency and responsiveness, particularly for section spacing and alignment on different screen sizes.

Layout and spacing improvements:

* Updated the `SectionText` styled component to set a larger `marginBottom` for desktop and adjusted both `marginTop` and `marginBottom` for mobile screens to ensure consistent vertical spacing.
* Modified the `SectionWrapper` styled component to increase the top padding on desktop and restore the original padding for mobile devices, enhancing the visual separation of sections across breakpoints.

Minor style fixes:

* Set the `margin` of `SectionTitle` to `0` to remove unwanted spacing above section titles.

<img width="197" height="445" alt="image" src="https://github.com/user-attachments/assets/dfa39cb9-f4a8-44f8-a4f0-48cbc775a723" />
